### PR TITLE
refactor: move filters to a single type + extract with pick

### DIFF
--- a/src/tmdb/apis/account/types.ts
+++ b/src/tmdb/apis/account/types.ts
@@ -9,6 +9,7 @@ import { ListItem } from '../lists/types'
 import { MovieItem } from '../movies/types'
 import { TVShowItem } from '../tv/types'
 import { TVEpisodeItem } from '../tv-episodes/types'
+import { Filters } from 'src/types/filters'
 
 export type Account = {
   id: number
@@ -24,17 +25,7 @@ export type Account = {
   }
 }
 
-type MediaFilters = {
-  session_id: string
-  page?: number
-  language?: LanguageCode
-  sort_by?: 'created_at.asc' | 'created_at.desc'
-}
-
-export type DetailsFilters = {
-  session_id: string
-}
-
+// Body
 export type MarkAsFavoriteBody = {
   media_type: 'movie' | 'tv'
   media_id: number
@@ -48,6 +39,14 @@ export type AddToWatchlistBody = {
 }
 
 // Filters
+type SortByFilter = { sort_by?: 'created_at.asc' | 'created_at.desc' }
+type SessionIdFilter = Required<Pick<Filters, 'session_id'>>
+
+type MediaFilters = SessionIdFilter &
+  SortByFilter &
+  Pick<Filters, 'page' | 'language'>
+
+export type DetailsFilters = SessionIdFilter
 export type CreatedListsFilters = Omit<MediaFilters, 'sort_by'>
 export type FavoriteMoviesFilters = MediaFilters
 export type FavoriteTVShowsFilters = MediaFilters
@@ -56,8 +55,8 @@ export type RatedTVShowsFilters = MediaFilters
 export type RatedTVEpisodesFilters = MediaFilters
 export type MovieWatchlistFilters = MediaFilters
 export type TVShowWatchlistFilters = MediaFilters
-export type MarkAsFavoriteFilters = Pick<MediaFilters, 'session_id'>
-export type AddToWatchlistFilters = Pick<MediaFilters, 'session_id'>
+export type MarkAsFavoriteFilters = SessionIdFilter
+export type AddToWatchlistFilters = SessionIdFilter
 
 // Responses
 type ListsResponse = TMDBResponseList<ListItem[]>

--- a/src/tmdb/apis/changes/types.ts
+++ b/src/tmdb/apis/changes/types.ts
@@ -1,10 +1,7 @@
 import { Nullable, TMDBResponseList } from 'src/types'
+import { Filters } from 'src/types/filters'
 
-export type ChangesFilters = {
-  end_date?: string
-  start_date?: string
-  page?: number
-}
+export type ChangesFilters = Pick<Filters, 'end_date' | 'start_date' | 'page'>
 
 export type ChangesResponse = TMDBResponseList<{
   id: number

--- a/src/tmdb/apis/collections/types.ts
+++ b/src/tmdb/apis/collections/types.ts
@@ -1,11 +1,6 @@
-import {
-  Image,
-  Nullable,
-  LanguageCode,
-  Translation,
-  TMDBResponse,
-} from 'src/types'
+import { Image, Nullable, Translation, TMDBResponse } from 'src/types'
 import { MovieItem } from '../movies/types'
+import { Filters } from 'src/types/filters'
 
 export type Collection = {
   id: number
@@ -37,9 +32,7 @@ export type CollectionTranslations = {
 }
 
 // Filters
-export type CollectionsFilters = {
-  language?: LanguageCode
-}
+export type CollectionsFilters = Pick<Filters, 'language'>
 
 // Responses
 export type CollectionDetailsResponse = TMDBResponse<Collection>

--- a/src/tmdb/apis/discover/types.ts
+++ b/src/tmdb/apis/discover/types.ts
@@ -1,96 +1,80 @@
-import { CountryCode, LanguageCode, TMDBResponseList } from 'src/types'
-import { CertificationCode } from '../certifications/types'
+import { TMDBResponseList } from 'src/types'
 import { MovieItem } from '../movies/types'
 import { TVShowItem } from '../tv/types'
+import { Filters } from 'src/types/filters'
 
-type SortBy =
-  | 'popularity.asc'
-  | 'popularity.desc'
-  | 'release_date.asc'
-  | 'release_date.desc'
-  | 'revenue.asc'
-  | 'revenue.desc'
-  | 'primary_release_date.asc'
-  | 'primary_release_date.desc'
-  | 'original_title.asc'
-  | 'original_title.desc'
-  | 'vote_average.asc'
-  | 'vote_average.desc'
-  | 'vote_count.asc'
-  | 'vote_count.desc'
+export type MovieFilters = Pick<
+  Filters,
+  | 'page'
+  | 'sort_by'
+  | 'language'
+  | 'region'
+  | 'certification_country'
+  | 'certification'
+  | 'include_adult'
+  | 'include_video'
+  | 'year'
+  | 'primary_release_year'
+  | 'with_release_type'
+  | 'with_cast'
+  | 'with_crew'
+  | 'with_people'
+  | 'with_companies'
+  | 'without_companies'
+  | 'with_genres'
+  | 'without_genres'
+  | 'with_keywords'
+  | 'without_keyword'
+  | 'with_original_language'
+  | 'watch_region'
+  | 'with_watch_providers'
+  | 'with_watch_monetization_types'
+  | 'screened_theatrically'
+  | 'with_runtime.gte'
+  | 'with_runtime.lte'
+  | 'primaty_release_date.gte'
+  | 'primaty_release_date.lte'
+  | 'release_date.gte'
+  | 'release_date.lte'
+  | 'certification.lte'
+  | 'certification.gte'
+  | 'vote_count.gte'
+  | 'vote_count.lte'
+  | 'vote_average.gte'
+  | 'vote_average.lte'
+>
 
-type MonetizationTypes = 'flatrate' | 'free' | 'ads' | 'rent' | 'buy'
-
-export type MovieFilters = {
-  page?: number
-  sort_by?: SortBy
-  language?: LanguageCode
-  region?: CountryCode
-  certification_country?: CountryCode
-  certification?: CertificationCode
-  include_adult?: boolean
-  include_video?: boolean
-  year?: number
-  primary_release_year?: number
-  with_release_type?: number
-  with_cast?: string[]
-  with_crew?: string[]
-  with_people?: string[]
-  with_companies?: string[]
-  without_companies?: string[]
-  with_genres?: string[]
-  without_genres?: string[]
-  with_keywords?: string[]
-  without_keyword?: string[]
-  with_original_language?: LanguageCode
-  watch_region?: CountryCode
-  with_watch_providers?: string[]
-  with_watch_monetization_types?: MonetizationTypes
-  screened_theatrically?: boolean
-  'with_runtime.gte'?: number
-  'with_runtime.lte'?: number
-  'primaty_release_date.gte'?: string
-  'primaty_release_date.lte'?: string
-  'release_date.gte'?: string
-  'release_date.lte'?: string
-  'certification.lte'?: string
-  'certification.gte'?: string
-  'vote_count.gte'?: number
-  'vote_count.lte'?: number
-  'vote_average.gte'?: number
-  'vote_average.lte'?: number
-}
-
-export type TVShowFilters = {
-  language?: LanguageCode
-  sort_by?: SortBy
-  'air_date.gte'?: string
-  'air_date.lte'?: string
-  'first_air_date.gte'?: string
-  'first_air_date.lte'?: string
-  first_air_date_year?: number
-  page?: number
-  timezone?: string
-  'vote_average.gte'?: number
-  'vote_count.gte'?: number
-  with_genres?: string[]
-  with_networks?: string[]
-  without_genres?: string[]
-  'with_runtime.gte'?: number
-  'with_runtime.lte'?: number
-  include_null_first_air_dates?: boolean
-  with_original_language?: LanguageCode
-  without_keywords?: string[]
-  screened_theatrically?: boolean
-  with_companies?: string[]
-  with_keywords?: string[]
-  with_watch_providers?: string[]
-  watch_region?: CountryCode
-  with_watch_monetization_types?: MonetizationTypes
-  with_status?: ('0' | '1' | '2' | '3' | '4' | '5')[]
-  with_type?: ('0' | '1' | '2' | '3' | '4' | '5' | '6')[]
-  without_companies?: string[]
-}
+export type TVShowFilters = Pick<
+  Filters,
+  | 'language'
+  | 'sort_by'
+  | 'air_date.gte'
+  | 'air_date.lte'
+  | 'first_air_date.gte'
+  | 'first_air_date.lte'
+  | 'first_air_date_year'
+  | 'page'
+  | 'timezone'
+  | 'vote_average.gte'
+  | 'vote_count.gte'
+  | 'with_genres'
+  | 'with_networks'
+  | 'without_genres'
+  | 'with_runtime.gte'
+  | 'with_runtime.lte'
+  | 'include_null_first_air_dates'
+  | 'with_original_language'
+  | 'without_keywords'
+  | 'screened_theatrically'
+  | 'with_companies'
+  | 'with_keywords'
+  | 'with_watch_providers'
+  | 'watch_region'
+  | 'with_watch_monetization_types'
+  | 'with_status'
+  | 'with_type'
+  | 'without_companies'
+>
 
 // Responses
 export type MovieResponse = TMDBResponseList<MovieItem[]>

--- a/src/tmdb/apis/find/types.ts
+++ b/src/tmdb/apis/find/types.ts
@@ -1,14 +1,13 @@
-import { TMDBResponse, LanguageCode, ExternalId } from 'src/types'
+import { TMDBResponse } from 'src/types'
 import { PersonItem } from '../people/types'
 import { TVShowItem } from '../tv/types'
 import { TVEpisodeItem } from '../tv-episodes/types'
 import { TVSeasonItem } from '../tv-seasons/types'
 import { MovieItem } from '../movies/types'
+import { Filters } from 'src/types/filters'
 
-export type FindFilters = {
-  language?: LanguageCode
-  external_source: keyof ExternalId
-}
+export type FindFilters = Pick<Filters, 'language'> &
+  Required<Pick<Filters, 'external_source'>>
 
 export type FindResponse = TMDBResponse<{
   movie_results: MovieItem[]

--- a/src/tmdb/apis/genres/types.ts
+++ b/src/tmdb/apis/genres/types.ts
@@ -1,4 +1,5 @@
-import { TMDBResponse, LanguageCode } from 'src/types'
+import { TMDBResponse } from 'src/types'
+import { Filters } from 'src/types/filters'
 
 export enum GenreCode {
   ACTION = 28,
@@ -27,10 +28,10 @@ export interface Genre {
   name: string
 }
 
-export type GenresFilters = {
-  language?: LanguageCode
-}
+// Filters
+export type GenresFilters = Pick<Filters, 'language'>
 
+// Responses
 export type GenresResponse = TMDBResponse<{
   genres: Genre[]
 }>

--- a/src/tmdb/apis/guest-sessions/types.ts
+++ b/src/tmdb/apis/guest-sessions/types.ts
@@ -1,12 +1,8 @@
-import { LanguageCode, TMDBResponseList } from 'src/types'
+import { TMDBResponseList } from 'src/types'
 import { MovieItem } from '../movies/types'
 import { TVShowItem } from '../tv/types'
 import { TVEpisodeItem } from '../tv-episodes/types'
-
-export type RatedFilters = {
-  language?: LanguageCode
-  sort_by?: 'created_at.asc' | 'created_at.desc'
-}
+import { Filters } from 'src/types/filters'
 
 type Rating = { rating: number }
 
@@ -14,6 +10,11 @@ type MovieItemRating = MovieItem & Rating
 type TVShowItemRating = TVShowItem & Rating
 type TVEpisodeItemRating = TVEpisodeItem & Rating
 
+// Filters
+export type SortByFilter = { sort_by?: 'created_at.asc' | 'created_at.desc' }
+export type RatedFilters = Pick<Filters, 'language'> & SortByFilter
+
+// Responses
 export type RatedMoviesResponse = TMDBResponseList<MovieItemRating[]>
 export type RatedTVShowsResponse = TMDBResponseList<TVShowItemRating[]>
 export type RatedTVEpisodesResponse = TMDBResponseList<TVEpisodeItemRating[]>

--- a/src/tmdb/apis/keywords/types.ts
+++ b/src/tmdb/apis/keywords/types.ts
@@ -1,15 +1,15 @@
-import { LanguageCode, TMDBResponse, TMDBResponseList, WithId } from 'src/types'
+import { TMDBResponse, TMDBResponseList, WithId } from 'src/types'
 import { MovieItem } from '../movies/types'
+import { Filters } from 'src/types/filters'
 
 export type Keyword = {
   id: number
   name: string
 }
 
-export type MoviesFilters = {
-  language?: LanguageCode
-  include_adult?: boolean
-}
+// Filters
+export type MoviesFilters = Pick<Filters, 'include_adult' | 'language'>
 
+// Responses
 export type DetailsResponse = TMDBResponse<Keyword>
 export type MoviesResponse = WithId<TMDBResponseList<MovieItem[]>>

--- a/src/tmdb/apis/lists/types.ts
+++ b/src/tmdb/apis/lists/types.ts
@@ -6,6 +6,7 @@ import {
 } from 'src/types'
 import { MovieItem } from '../movies/types'
 import { TVShowItem } from '../tv/types'
+import { Filters } from 'src/types/filters'
 
 export type List = {
   id: number
@@ -32,13 +33,12 @@ export type ListItem = Pick<
 >
 
 // Filters
-type LanguageFilter = { language?: LanguageCode }
-type MediaIdFilter = { media_id: number }
-type SessionIdFilter = { session_id: string }
+type MediaIdFilter = Required<Pick<Filters, 'media_id'>>
+type SessionIdFilter = Required<Pick<Filters, 'session_id'>>
 
-export type DetailsFilters = LanguageFilter
+export type DetailsFilters = Pick<Filters, 'language'>
 
-export type ItemStatusFilters = { movie_id: number }
+export type ItemStatusFilters = Pick<Filters, 'movie_id'>
 
 export type CreateListFilters = SessionIdFilter
 
@@ -46,12 +46,11 @@ export type AddItemFilters = SessionIdFilter
 
 export type RemoveItemFilters = SessionIdFilter
 
-export type ClearListFilters = SessionIdFilter & {
-  confirm: boolean
-}
+export type ClearListFilters = SessionIdFilter & Pick<Filters, 'confirm'>
 
 export type DeleteListFilters = SessionIdFilter
 
+// Body
 export type CreateListBody = {
   name: string
   description: string

--- a/src/tmdb/apis/movies/types.ts
+++ b/src/tmdb/apis/movies/types.ts
@@ -9,7 +9,6 @@ import {
   Country,
   Language,
   Video,
-  AppendToResponse,
   WithId,
   ExternalId,
   GenericResponse,
@@ -22,6 +21,7 @@ import { CertificationCode } from '../certifications/types'
 import { ListItem } from '../lists/types'
 import { ReviewItem } from '../reviews/types'
 import { WatchProvider } from '../watch-providers/types'
+import { Filters } from 'src/types/filters'
 
 export type Movie = {
   id: number
@@ -169,49 +169,42 @@ export type MovieWatchProviders = {
 }
 
 // Filters
-type AppendToResponseFilters = { append_to_response: AppendToResponse[] }
-type RegionFilter = { region?: CountryCode }
-type CountryFilter = { country?: CountryCode }
-type LanguageFilter = { language?: LanguageCode }
-type IncludeImageLanguageFilter = { include_image_language?: LanguageCode[] }
-type PageFilter = { page?: number }
-type SessionFilters = { session_id: string; guest_session_id?: string }
-type OptionalSessionFilters = { session_id?: string; guest_session_id?: string }
-type DateRangeFilters = { start_date?: string; end_date?: string }
+type SessionFilters = Pick<Filters, 'guest_session_id'> &
+  Required<Pick<Filters, 'session_id'>>
 
-export type DetailsFilters = AppendToResponseFilters & LanguageFilter
+export type DetailsFilters = Pick<Filters, 'append_to_response' | 'language'>
 
 export type AccountStatesFilters = SessionFilters
 
-export type AlternativeTitlesFilters = CountryFilter
+export type AlternativeTitlesFilters = Pick<Filters, 'country'>
 
-export type ChangesFilters = DateRangeFilters & PageFilter
+export type ChangesFilters = Pick<Filters, 'page' | 'start_date' | 'end_date'>
 
-export type CreditsFilters = LanguageFilter
+export type CreditsFilters = Pick<Filters, 'language'>
 
-export type ImagesFilters = LanguageFilter & IncludeImageLanguageFilter
+export type ImagesFilters = Pick<Filters, 'language' | 'include_image_language'>
 
-export type ListsFilters = LanguageFilter & PageFilter
+export type ListsFilters = Pick<Filters, 'language' | 'page'>
 
-export type RecommendationsFilters = LanguageFilter & PageFilter
+export type RecommendationsFilters = Pick<Filters, 'language' | 'page'>
 
-export type ReviewsFilters = LanguageFilter & PageFilter
+export type ReviewsFilters = Pick<Filters, 'language' | 'page'>
 
-export type SimilarFilters = LanguageFilter & PageFilter
+export type SimilarFilters = Pick<Filters, 'language' | 'page'>
 
-export type VideosFilters = LanguageFilter & IncludeImageLanguageFilter
+export type VideosFilters = Pick<Filters, 'language' | 'include_image_language'>
 
-export type LatestFilters = LanguageFilter
+export type LatestFilters = Pick<Filters, 'language'>
 
-export type RateFilters = OptionalSessionFilters
+export type RateFilters = Pick<Filters, 'session_id' | 'guest_session_id'>
 
-export type NowPlayingFilters = LanguageFilter & RegionFilter & PageFilter
+export type NowPlayingFilters = Pick<Filters, 'language' | 'page' | 'region'>
 
-export type PopularFilters = LanguageFilter & RegionFilter & PageFilter
+export type PopularFilters = Pick<Filters, 'language' | 'page' | 'region'>
 
-export type TopRatedFilters = LanguageFilter & RegionFilter & PageFilter
+export type TopRatedFilters = Pick<Filters, 'language' | 'page' | 'region'>
 
-export type UpcomingFilters = LanguageFilter & RegionFilter & PageFilter
+export type UpcomingFilters = Pick<Filters, 'language' | 'page' | 'region'>
 
 // Body
 export type RateBody = {

--- a/src/tmdb/apis/people/types.ts
+++ b/src/tmdb/apis/people/types.ts
@@ -1,9 +1,7 @@
 import {
-  AppendToResponse,
   Department,
   ExternalId,
   Image,
-  LanguageCode,
   Nullable,
   TMDBResponse,
   TMDBResponseList,
@@ -12,6 +10,7 @@ import {
 } from 'src/types'
 import { MovieItem } from '../movies/types'
 import { TVShowItem } from '../tv/types'
+import { Filters } from 'src/types/filters'
 
 export type Person = {
   id: number
@@ -115,27 +114,20 @@ export type PersonTranslations = {
 }
 
 // Filters
-export type DetailsFilters = {
-  language?: LanguageCode
-  append_to_response?: AppendToResponse[]
-}
+export type DetailsFilters = Pick<Filters, 'language' | 'append_to_response'>
 
-export type ChangesFilters = {
-  page?: number
-  start_date?: string
-  end_date?: string
-}
+export type ChangesFilters = Pick<Filters, 'page' | 'start_date' | 'end_date'>
 
-export type LanguageFilters = {
-  language?: LanguageCode
-}
+export type LanguageFilters = Pick<Filters, 'language'>
 
-export type LanguageAndPageFilters = {
-  page?: number
-  language?: LanguageCode
-}
+export type LanguageAndPageFilters = Pick<Filters, 'page' | 'language'>
 
 // Responses
+type TaggedImage = Image & {
+  media: MovieItem | TVShowItem
+  media_type: 'tv' | 'movie'
+}
+
 export type DetailsResponse = TMDBResponse<Person>
 
 export type ChangesResponse = TMDBResponse<PersonChanges>
@@ -147,11 +139,6 @@ export type TVCreditsResponse = TMDBResponse<PersonTVCredits>
 export type CombinedCreditsResponse = TMDBResponse<PersonCombinedCredits>
 
 export type ExternalIdsResponse = TMDBResponse<ExternalId>
-
-type TaggedImage = Image & {
-  media: MovieItem | TVShowItem
-  media_type: 'tv' | 'movie'
-}
 
 export type ImagesResponse = WithId<TMDBResponseList<Image>>
 

--- a/src/tmdb/apis/search/types.ts
+++ b/src/tmdb/apis/search/types.ts
@@ -1,46 +1,34 @@
-import { CountryCode, LanguageCode, TMDBResponseList } from 'src/types'
+import { TMDBResponseList } from 'src/types'
 import { CompanyItem } from '../companies/types'
 import { CollectionItem } from '../collections/types'
 import { Keyword } from '../keywords/types'
 import { MovieItem } from '../movies/types'
 import { TVShowItem } from '../tv/types'
 import { PersonItem } from '../people/types'
+import { Filters } from 'src/types/filters'
 
-export type SearchFilters = {
-  query: string
-  page?: number
-}
+// Filters
+export type SearchFilters = Required<Pick<Filters, 'query'>> &
+  Pick<Filters, 'page'>
 
-export type CollectionsFilters = SearchFilters & {
-  language?: LanguageCode
-}
+export type CollectionsFilters = SearchFilters & Pick<Filters, 'language'>
 
-export type MoviesFilters = SearchFilters & {
-  language?: LanguageCode
-  include_adult?: boolean
-  region?: CountryCode
-  year?: number
-  primary_release_year?: number
-}
+export type MoviesFilters = SearchFilters &
+  Pick<
+    Filters,
+    'language' | 'include_adult' | 'region' | 'year' | 'primary_release_year'
+  >
 
-export type MultiSearchFilters = SearchFilters & {
-  language?: LanguageCode
-  include_adult?: boolean
-  region?: CountryCode
-}
+export type MultiSearchFilters = SearchFilters &
+  Pick<Filters, 'language' | 'include_adult' | 'region'>
 
-export type PeopleFilters = SearchFilters & {
-  language?: LanguageCode
-  include_adult?: boolean
-  region?: CountryCode
-}
+export type PeopleFilters = SearchFilters &
+  Pick<Filters, 'language' | 'include_adult' | 'region'>
 
-export type TVShowsFilters = SearchFilters & {
-  language?: LanguageCode
-  include_adult?: boolean
-  first_air_date_year?: number
-}
+export type TVShowsFilters = SearchFilters &
+  Pick<Filters, 'language' | 'include_adult' | 'first_air_date_year'>
 
+// Responses
 type MultiSearch = MovieItem | TVShowItem | PersonItem
 
 export type CompaniesResponse = TMDBResponseList<CompanyItem[]>

--- a/src/tmdb/apis/trending/types.ts
+++ b/src/tmdb/apis/trending/types.ts
@@ -3,6 +3,7 @@ import { MovieItem } from '../movies/types'
 import { TVShowItem } from '../tv/types'
 import { PersonItem } from '../people/types'
 
+// Responses
 type MediaList = (MovieItem | TVShowItem | PersonItem)[]
 
 export type TrendingResponse = TMDBResponseList<MediaList>

--- a/src/tmdb/apis/tv-episode-groups/types.ts
+++ b/src/tmdb/apis/tv-episode-groups/types.ts
@@ -1,6 +1,7 @@
-import { LanguageCode, Nullable, TMDBResponse } from 'src/types'
+import { Nullable, TMDBResponse } from 'src/types'
 import { NetworkItem } from '../networks/types'
 import { TVEpisode } from '../tv-episodes/types'
+import { Filters } from 'src/types/filters'
 
 export type TVEpisodeGroup = {
   id: string
@@ -19,9 +20,7 @@ export type TVEpisodeGroup = {
 }
 
 // Filters
-export type DetailsFilters = {
-  language?: LanguageCode
-}
+export type DetailsFilters = Pick<Filters, 'language'>
 
 // Responses
 export type DetailsResponse = TMDBResponse<TVEpisodeGroup>

--- a/src/tmdb/apis/tv-episodes/types.ts
+++ b/src/tmdb/apis/tv-episodes/types.ts
@@ -1,5 +1,4 @@
 import {
-  AppendToResponse,
   Department,
   ExternalId,
   GenericResponse,
@@ -12,6 +11,7 @@ import {
 } from 'src/types'
 import { PersonCast, PersonCrew } from '../people/types'
 import { TVShowChanges } from '../tv/types'
+import { Filters } from 'src/types/filters'
 
 export type TVEpisode = {
   id: number
@@ -107,39 +107,22 @@ export type TVEpisodeVideos = {
 }
 
 // Filters
-export type DetailsFilters = {
-  language?: LanguageCode
-  append_to_response?: AppendToResponse[]
-}
+export type DetailsFilters = Pick<Filters, 'language' | 'append_to_response'>
 
-export type AccountStatesFilters = {
-  guest_session_id?: string
-  session_id?: string
-}
+export type AccountStatesFilters = Pick<
+  Filters,
+  'guest_session_id' | 'session_id'
+>
 
-export type ChangesFilters = {
-  start_date?: string
-  end_date?: string
-  page?: number
-}
+export type ChangesFilters = Pick<Filters, 'page' | 'end_date' | 'start_date'>
 
-export type CreditsFilters = {
-  language?: LanguageCode
-  append_to_response?: AppendToResponse[]
-}
+export type CreditsFilters = Pick<Filters, 'language' | 'append_to_response'>
 
-export type ImagesFilters = {
-  language?: LanguageCode
-}
+export type ImagesFilters = Pick<Filters, 'language'>
 
-export type RateFilters = {
-  guest_session_id?: string
-  session_id?: string
-}
+export type RateFilters = Pick<Filters, 'guest_session_id' | 'session_id'>
 
-export type VideosFilters = {
-  language?: LanguageCode
-}
+export type VideosFilters = Pick<Filters, 'language'>
 
 // Body
 export type RateBody = {

--- a/src/tmdb/apis/tv-seasons/types.ts
+++ b/src/tmdb/apis/tv-seasons/types.ts
@@ -1,5 +1,4 @@
 import {
-  AppendToResponse,
   ExternalId,
   Image,
   LanguageCode,
@@ -11,6 +10,7 @@ import {
 import { TVEpisode } from '../tv-episodes/types'
 import { PersonCast, PersonCrew } from '../people/types'
 import { TVShowPersonCast, TVShowPersonCrew } from '../tv/types'
+import { Filters } from 'src/types/filters'
 
 export type TVSeason = {
   _id: string
@@ -82,36 +82,26 @@ export type TVSeasonVideos = {
 }
 
 // Filters
-type LanguageFilter = {
-  language?: LanguageCode
-}
+export type DetailsFilters = Pick<Filters, 'language' | 'append_to_response'>
 
-export type DetailsFilters = LanguageFilter & {
-  append_to_response?: AppendToResponse[]
-}
+export type AccountStatesFilters = Pick<
+  Filters,
+  'language' | 'guest_session_id' | 'session_id'
+>
 
-export type AccountStatesFilters = LanguageFilter & {
-  guest_session_id?: string
-  session_id?: string
-}
+export type AggregateCreditsFilters = Pick<Filters, 'language'>
 
-export type AggregateCreditsFilters = LanguageFilter
+export type ChangesFilters = Pick<Filters, 'page' | 'start_date' | 'end_date'>
 
-export type ChangesFilters = {
-  start_date?: string
-  end_date?: string
-  page?: number
-}
+export type CreditsFilters = Pick<Filters, 'language'>
 
-export type CreditsFilters = LanguageFilter
+export type ExternalIdsFilters = Pick<Filters, 'language'>
 
-export type ExternalIdsFilters = LanguageFilter
+export type ImagesFilters = Pick<Filters, 'language'>
 
-export type ImagesFilters = LanguageFilter
+export type TranslationFilters = Pick<Filters, 'language'>
 
-export type TranslationFilters = LanguageFilter
-
-export type VideosFilters = LanguageFilter
+export type VideosFilters = Pick<Filters, 'language'>
 
 // Responses
 export type DetailsResponse = TMDBResponse<TVSeason>

--- a/src/tmdb/apis/tv/types.ts
+++ b/src/tmdb/apis/tv/types.ts
@@ -1,5 +1,4 @@
 import {
-  AppendToResponse,
   Country,
   CountryCode,
   Department,
@@ -24,6 +23,7 @@ import { TVEpisodeGroup } from '../tv-episode-groups/types'
 import { Keyword } from '../keywords/types'
 import { ReviewItem } from '../reviews/types'
 import { WatchProvider } from '../watch-providers/types'
+import { Filters } from 'src/types/filters'
 
 // Models/Entities
 export type TVAuthor = {
@@ -219,51 +219,48 @@ export type TVShowVideos = {
 }
 
 // Filters
-type AppendToResponseFilters = { append_to_response?: AppendToResponse[] }
-type LanguageFilter = { language?: LanguageCode }
-type PageFilter = { page?: number }
-type OptionalSessionFilters = { session_id?: string; guest_session_id?: string }
-type DateRangeFilters = { start_date?: string; end_date?: string }
+export type DetailsFilters = Pick<Filters, 'language' | 'append_to_response'>
 
-export type DetailsFilters = LanguageFilter & AppendToResponseFilters
+export type AccountStatesFilters = Pick<
+  Filters,
+  'language' | 'guest_session_id' | 'session_id'
+>
 
-export type AccountStatesFilters = LanguageFilter & OptionalSessionFilters
+export type AggregateCreditsFilters = Pick<Filters, 'language'>
 
-export type AggregateCreditsFilters = LanguageFilter
+export type AlternativeTitlesFilters = Pick<Filters, 'language'>
 
-export type AlternativeTitlesFilters = LanguageFilter
+export type ChangesFilters = Pick<Filters, 'page' | 'start_date' | 'end_date'>
 
-export type ChangesFilters = PageFilter & DateRangeFilters
+export type ContentRatingsFilters = Pick<Filters, 'language'>
 
-export type ContentRatingsFilters = LanguageFilter
+export type CreditsFilters = Pick<Filters, 'language'>
 
-export type CreditsFilters = LanguageFilter
+export type EpisodeGroupsFilters = Pick<Filters, 'language'>
 
-export type EpisodeGroupsFilters = LanguageFilter
+export type ExternalIdsFilters = Pick<Filters, 'language'>
 
-export type ExternalIdsFilters = LanguageFilter
+export type ImagesFilters = Pick<Filters, 'language'>
 
-export type ImagesFilters = LanguageFilter
+export type RecommendationsFilters = Pick<Filters, 'language' | 'page'>
 
-export type RecommendationsFilters = LanguageFilter & PageFilter
+export type ReviewsFilters = Pick<Filters, 'language' | 'page'>
 
-export type ReviewsFilters = LanguageFilter & PageFilter
+export type SimilarFilters = Pick<Filters, 'language' | 'page'>
 
-export type SimilarFilters = LanguageFilter & PageFilter
+export type VideosFilters = Pick<Filters, 'language'>
 
-export type VideosFilters = LanguageFilter
+export type RateFilters = Pick<Filters, 'guest_session_id' | 'session_id'>
 
-export type RateFilters = OptionalSessionFilters
+export type LatestFilters = Pick<Filters, 'language'>
 
-export type LatestFilters = LanguageFilter
+export type AiringTodayFilters = Pick<Filters, 'language' | 'page'>
 
-export type AiringTodayFilters = LanguageFilter & PageFilter
+export type OnTheAirFilters = Pick<Filters, 'language' | 'page'>
 
-export type OnTheAirFilters = LanguageFilter & PageFilter
+export type PopularFilters = Pick<Filters, 'language' | 'page'>
 
-export type PopularFilters = LanguageFilter & PageFilter
-
-export type TopRatedFilters = LanguageFilter & PageFilter
+export type TopRatedFilters = Pick<Filters, 'language' | 'page'>
 
 // Body
 export type RateBody = {

--- a/src/tmdb/apis/watch-providers/types.ts
+++ b/src/tmdb/apis/watch-providers/types.ts
@@ -1,4 +1,5 @@
-import { CountryCode, LanguageCode, TMDBResponse } from 'src/types'
+import { CountryCode, TMDBResponse } from 'src/types'
+import { Filters } from 'src/types/filters'
 
 export type AvailableRegion = {
   iso_3166_1: CountryCode
@@ -14,14 +15,9 @@ export type WatchProvider = {
 }
 
 // Filters
-export type AvailableRegionsFilters = {
-  language?: LanguageCode
-}
+export type AvailableRegionsFilters = Pick<Filters, 'language'>
 
-export type WatchProvidersFilters = {
-  language?: LanguageCode
-  watch_region?: CountryCode
-}
+export type WatchProvidersFilters = Pick<Filters, 'language' | 'watch_region'>
 
 // Responses
 export type AvailableRegionsResponse = TMDBResponse<{

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -1,0 +1,83 @@
+import { CertificationCode } from 'src/tmdb/apis/certifications/types'
+import { AppendToResponse, CountryCode, ExternalId, LanguageCode } from '.'
+
+type SortBy =
+  | 'popularity.asc'
+  | 'popularity.desc'
+  | 'release_date.asc'
+  | 'release_date.desc'
+  | 'revenue.asc'
+  | 'revenue.desc'
+  | 'primary_release_date.asc'
+  | 'primary_release_date.desc'
+  | 'original_title.asc'
+  | 'original_title.desc'
+  | 'vote_average.asc'
+  | 'vote_average.desc'
+  | 'vote_count.asc'
+  | 'vote_count.desc'
+
+type MonetizationTypes = 'flatrate' | 'free' | 'ads' | 'rent' | 'buy'
+
+export type Filters = {
+  page?: number
+  sort_by?: SortBy
+  language?: LanguageCode
+  region?: CountryCode
+  certification_country?: CountryCode
+  certification?: CertificationCode
+  include_adult?: boolean
+  include_video?: boolean
+  year?: number
+  primary_release_year?: number
+  with_release_type?: number
+  with_cast?: string[]
+  with_crew?: string[]
+  with_people?: string[]
+  with_companies?: string[]
+  without_companies?: string[]
+  with_genres?: string[]
+  without_genres?: string[]
+  with_keywords?: string[]
+  without_keyword?: string[]
+  with_original_language?: LanguageCode
+  watch_region?: CountryCode
+  with_watch_providers?: string[]
+  with_watch_monetization_types?: MonetizationTypes
+  screened_theatrically?: boolean
+  'with_runtime.gte'?: number
+  'with_runtime.lte'?: number
+  'primaty_release_date.gte'?: string
+  'primaty_release_date.lte'?: string
+  'release_date.gte'?: string
+  'release_date.lte'?: string
+  'certification.lte'?: string
+  'certification.gte'?: string
+  'vote_count.gte'?: number
+  'vote_count.lte'?: number
+  'vote_average.gte'?: number
+  'vote_average.lte'?: number
+  'air_date.gte'?: string
+  'air_date.lte'?: string
+  'first_air_date.gte'?: string
+  'first_air_date.lte'?: string
+  first_air_date_year?: number
+  timezone?: string
+  with_networks?: string[]
+  include_image_language?: LanguageCode[]
+  include_null_first_air_dates?: boolean
+  without_keywords?: string[]
+  with_status?: ('0' | '1' | '2' | '3' | '4' | '5')[]
+  with_type?: ('0' | '1' | '2' | '3' | '4' | '5' | '6')[]
+  end_date?: string
+  start_date?: string
+  append_to_response?: AppendToResponse[]
+  guest_session_id?: string
+  session_id?: string
+  external_source?: keyof ExternalId
+  media_id?: number
+  movie_id?: number
+  confirm?: boolean
+  country?: CountryCode
+  query?: string
+}


### PR DESCRIPTION
## 💬 PR description
- Adds single Filters type, with all available query filters inside of it
- Changes current filters usage to `Pick<Filters, keys>`

## 🎲 Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change which updates/fix functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (e.g.: dependency upgrade, pipeline update)
- [ ] Docs change (change related to documentation)
- [ ] BREAKING CHANGE (existing functionality changes)

## 🙇‍♂️ PR checklist
- [x] I wrote proper tests
- [x] I wrote a description of requested changes
- [x] I performed a self-review on my own code
- [x] I set proper PR labels
- [x] I have update the documentation accordingly
- [x] My code follows the code style of this project

## ✅ Code review checklist
Usually checked by reviewers
- [x] Code is self-documenting and easy to understand
- [x] There is no commented out code
- [x] There is no unecessary logging or debugging code
- [x] Errors are handled
- [x] Naming of methods, variables, and classes are proper
- [x] Changes are documented in README.md (if necessary)
